### PR TITLE
Remove aspect ratio match logic, new HLS player design doesn't require it

### DIFF
--- a/Sources/HMSRoomModels/HLS Player/HMSHLSPlayerRepresentable.swift
+++ b/Sources/HMSRoomModels/HLS Player/HMSHLSPlayerRepresentable.swift
@@ -34,6 +34,8 @@ internal struct HMSHLSViewRepresentable: UIViewRepresentable {
         videoViewController.allowsPictureInPicturePlayback = false
         videoViewController.canStartPictureInPictureAutomaticallyFromInline = false
         
+        videoViewController.videoGravity = .resizeAspect
+        
         AVPlayerModel.shared.currentAVPlayerInstance = videoViewController
         
         return videoViewController.view

--- a/Sources/HMSRoomModels/HLS Player/HMSHLSPlayerView.swift
+++ b/Sources/HMSRoomModels/HLS Player/HMSHLSPlayerView.swift
@@ -53,14 +53,6 @@ public struct HMSHLSPlayerView<VideoOverlay> : View where VideoOverlay : View {
         }
         func onResolutionChanged(videoSize: CGSize) {
             onResolutionChanged?(videoSize)
-            Task { @MainActor in
-                if videoSize.width > videoSize.height {
-                    AVPlayerModel.shared.currentAVPlayerInstance?.videoGravity = .resizeAspect
-                }
-                else {
-                    AVPlayerModel.shared.currentAVPlayerInstance?.videoGravity = .resizeAspectFill
-                }
-            }
         }
     }
     


### PR DESCRIPTION
Remove aspect ratio match logic because new HLS player design doesn't require it