### PR TITLE
Fixed: No audio when changing role from non-publishing to publishing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,8 +56,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "WebRTC",
-            url: "https://github.com/100mslive/webrtc-ios/releases/download/1.0.6169/WebRTC.xcframework.zip",
-            checksum: "d07b1c68defc145067a4e684bc2a88911803871eeec702b2cb00cb18146898f5"
+            url: "https://github.com/100mslive/webrtc-ios/releases/download/1.0.6170/WebRTC.xcframework.zip",
+            checksum: "5f5f6ed16e9e225f92aa8755604461fa76c93c1171899b68af59e73cc1310fb4"
         ),
         .binaryTarget(
             name: "HMSBroadcastExtensionSDK",


### PR DESCRIPTION
Using latest version of webrtc with fix for mic not accessible when changing role from non-publishing to publishing